### PR TITLE
Update all examples to use Automated Test Brand gallery / product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.DS_Store

--- a/spirit-galleries/gallery-carousel/dev-override.html
+++ b/spirit-galleries/gallery-carousel/dev-override.html
@@ -5,12 +5,12 @@
 </head>
 <body>
   <div style="max-width: 960px; margin: auto">
-    <h1>Gallery Carousel (DEV)</h1>
+    <h1>Gallery Carousel Override (DEV)</h1>
     <script
       src="https://likeshop.dhdev.co/static/js/app/board-embed.js"
       type="text/javascript"
       data-name="dhboard"
-      data-gallery-id="852867"
+      data-gallery-id="2050548"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"

--- a/spirit-galleries/gallery-carousel/dev.html
+++ b/spirit-galleries/gallery-carousel/dev.html
@@ -10,13 +10,14 @@
       src="https://likeshop.dhdev.co/static/js/app/board-embed.js"
       type="text/javascript"
       data-name="dhboard"
-      data-gallery-id="852867"
+      data-gallery-id="2050548"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
       data-mobile-gap-size="4"
       data-call-to-action="learn_more"
       data-disable-product-new-tab="false"
+      data-show-price="true"
     ></script>
   </div>
 </body>

--- a/spirit-galleries/gallery-carousel/prod-override.html
+++ b/spirit-galleries/gallery-carousel/prod-override.html
@@ -5,12 +5,12 @@
 </head>
 <body>
   <div style="max-width: 960px; margin: auto">
-    <h1>Gallery Carousel (PROD)</h1>
+    <h1>Gallery Carousel Override (PROD)</h1>
     <script
       src="https://cdn.dashhudson.com/web/js/board-embed.js"
       type="text/javascript"
       data-name="dhboard"
-      data-gallery-id="852867"
+      data-gallery-id="2050548"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"

--- a/spirit-galleries/gallery-carousel/prod.html
+++ b/spirit-galleries/gallery-carousel/prod.html
@@ -10,13 +10,14 @@
       src="https://cdn.dashhudson.com/web/js/board-embed.js"
       type="text/javascript"
       data-name="dhboard"
-      data-gallery-id="852867"
+      data-gallery-id="2050548"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
       data-mobile-gap-size="4"
       data-call-to-action="learn_more"
       data-disable-product-new-tab="false"
+      data-show-price="true"
     ></script>
   </div>
 </body>

--- a/spirit-galleries/product-carousel/dev-override.html
+++ b/spirit-galleries/product-carousel/dev-override.html
@@ -5,13 +5,14 @@
 </head>
 <body>
   <div style="max-width: 960px; margin: auto">
-    <h1>Product Carousel (DEV)</h1>
+    <h1>Product Carousel Override (DEV)</h1>
     <script
       src="https://likeshop.dhdev.co/static/js/app/product-carousel-embed.js"
       type="text/javascript"
       data-name="dhproduct-carousel"
-      data-id="144"
+      data-id="3042"
       data-id-type="brand_id"
+      data-product-id="widget_synthetics"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
@@ -20,7 +21,6 @@
       data-autoplay="false"
       data-carousel-dots="true"
       data-disable-product-new-tab="false"
-      data-product-id="synthetics_dev_do_not_delete"
       data-override="ES"
       data-show-price="true"
     ></script>

--- a/spirit-galleries/product-carousel/dev.html
+++ b/spirit-galleries/product-carousel/dev.html
@@ -10,8 +10,9 @@
       src="https://likeshop.dhdev.co/static/js/app/product-carousel-embed.js"
       type="text/javascript"
       data-name="dhproduct-carousel"
-      data-id="144"
+      data-id="3042"
       data-id-type="brand_id"
+      data-product-id="widget_synthetics"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
@@ -20,6 +21,7 @@
       data-autoplay="false"
       data-carousel-dots="true"
       data-disable-product-new-tab="false"
+      data-show-price="true"
     ></script>
   </div>
 </body>

--- a/spirit-galleries/product-carousel/prod-override.html
+++ b/spirit-galleries/product-carousel/prod-override.html
@@ -5,13 +5,14 @@
 </head>
 <body>
   <div style="max-width: 960px; margin: auto">
-    <h1>Product Carousel (PROD)</h1>
+    <h1>Product Carousel Override (PROD)</h1>
     <script
       src="https://cdn.dashhudson.com/web/js/product-carousel-embed.js"
       type="text/javascript"
       data-name="dhproduct-carousel"
-      data-id="144"
+      data-id="3042"
       data-id-type="brand_id"
+      data-product-id="widget_synthetics"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
@@ -20,7 +21,6 @@
       data-autoplay="false"
       data-carousel-dots="true"
       data-disable-product-new-tab="false"
-      data-product-id="synthetics_prod_do_not_delete"
       data-override="ES"
       data-show-price="true"
     ></script>

--- a/spirit-galleries/product-carousel/prod.html
+++ b/spirit-galleries/product-carousel/prod.html
@@ -10,8 +10,9 @@
       src="https://cdn.dashhudson.com/web/js/product-carousel-embed.js"
       type="text/javascript"
       data-name="dhproduct-carousel"
-      data-id="144"
+      data-id="3042"
       data-id-type="brand_id"
+      data-product-id="widget_synthetics"
       data-row-size="3"
       data-gap-size="2"
       data-mobile-row-size="2"
@@ -20,6 +21,7 @@
       data-autoplay="false"
       data-carousel-dots="true"
       data-disable-product-new-tab="false"
+      data-show-price="true"
     ></script>
   </div>
 </body>


### PR DESCRIPTION
Switched the gallery and product to use the QA brand instead of sunny.today.

Will pause the tests, merge, update tests and the un-pause.

No reviews "required" but adding reviewers for visibility since we own this now.